### PR TITLE
multipart boundaries have a double dash prefix

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -57,7 +57,8 @@ impl<R> Multipart<R> where R: HttpRequest {
             return Err(req);     
         }
 
-        let boundary = req.boundary().unwrap().to_owned();
+        // multipart prefixes the boundary announced in the Content-Type header with a double dash "--"
+        let boundary = format!("--{}", req.boundary().unwrap().to_owned());
 
         debug!("Boundary: {}", boundary);
 


### PR DESCRIPTION
So the boundary that delimits actual content needs to prefix  "--" to
the boundary announced in the content type header