### PR TITLE
Rewrite test to be more robust, fix testing on Windows (breaks build)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ rand = "*"
 version = "*"
 optional = true
 
+[dev-dependencies.hyper]
+version = "*"
+# Disable SSL for testing purposes
+default-features = false


### PR DESCRIPTION
This test does break the build but it does so on purpose, because the previous test did not actually verify that the request parsing was working correctly.

This might be overkill, but it will make sure everything works.