### PR TITLE
Fix boundary corner cases suggestion

### DIFF
--- a/src/server/boundary.rs
+++ b/src/server/boundary.rs
@@ -40,6 +40,10 @@ impl<R> BoundaryReader<R> where R: Read {
                     self.search_idx = last_search_idx + search_idx;
 
                     if self.boundary_read {
+                        // if boundary is preceded by CRLF, include it
+                        if self.search_idx >= 2 && &buf[self.search_idx-2..self.search_idx] == b"\r\n" {
+                            self.search_idx = self.search_idx - 2;
+                        }
                         break;
                     }
                 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -58,7 +58,7 @@ impl<R> Multipart<R> where R: HttpRequest {
             return Err(req);     
         }
 
-        let boundary = format!("\r\n--{}", req.boundary().unwrap());
+        let boundary = format!("--{}", req.boundary().unwrap());
 
         debug!("Boundary: {}", boundary);
 
@@ -81,11 +81,11 @@ impl<R> Multipart<R> where R: HttpRequest {
     pub fn read_entry(&mut self) -> io::Result<Option<MultipartField<R>>> {
         if self.at_end { return Ok(None); }
 
-        let mut byte2 = [0u8; 2];
         try!(self.source.consume_boundary());
-        try!(self.source.read(&mut byte2));
 
-        self.at_end = &byte2 == b"--";
+        self.at_end = {
+            try!(self.read_line()) == "--\r\n"
+        };
         
         if !self.at_end {
             MultipartField::read_from(self)


### PR DESCRIPTION
- in boundary.rs : just search for CRLF if there was chars before the
boundary. Maybe this could be passed as a searched prefix to the
BoundaryReader.
- in mod.rs : removed CRLF prefix (see above), and added systematic
line read after boundary to eat the CRLF, and check for multipart end