### PR TITLE
Fix boundary parsing on partial reads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "multipart"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Austin Bonander <austin.bonander@gmail.com>"]
 
 description = "An extension to the Hyper HTTP library that provides support for POST multipart/form-data requests on for both client and server."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,9 @@ pub mod client;
 #[cfg(feature = "server")]
 pub mod server;
 
+#[cfg(all(test, feature = "client", feature = "server"))]
+mod local_test;
+
 const DIRNAME_LEN: usize = 12;
 
 fn temp_dir() -> PathBuf {

--- a/src/local_test.rs
+++ b/src/local_test.rs
@@ -1,14 +1,7 @@
-#[macro_use]
-extern crate log;
-extern crate env_logger;
-extern crate rand;
+use client::HttpRequest as ClientRequest;
+use client::HttpStream as ClientStream;
 
-extern crate multipart;
-
-use multipart::client::HttpRequest as ClientRequest;
-use multipart::client::HttpStream as ClientStream;
-
-use multipart::server::HttpRequest as ServerRequest;
+use server::HttpRequest as ServerRequest;
 
 use rand::Rng;
 use rand::distributions::{Range, Sample};
@@ -24,7 +17,7 @@ struct TestFields {
 
 #[test]
 fn local_test() {
-    env_logger::init().unwrap(); 
+    let _ = ::env_logger::init(); 
 
     let test_fields = gen_test_fields();
 
@@ -52,14 +45,14 @@ fn gen_test_fields() -> TestFields {
 }
 
 fn gen_range(min: usize, max: usize) -> usize {
-    Range::new(min, max).sample(&mut rand::weak_rng())
+    Range::new(min, max).sample(&mut ::rand::weak_rng())
 }
 
 fn gen_string() -> String {
     const MIN_LEN: usize = 3;
     const MAX_LEN: usize = 12;
 
-    let mut rng = rand::weak_rng();
+    let mut rng = ::rand::weak_rng();
     let str_len = gen_range(MIN_LEN, MAX_LEN);
 
     rng.gen_ascii_chars().take(str_len).collect()
@@ -69,7 +62,7 @@ fn gen_bytes() -> Vec<u8> {
     const MIN_LEN: usize = 8;
     const MAX_LEN: usize = 32;
 
-    let mut rng = rand::weak_rng();
+    let mut rng = ::rand::weak_rng();
     let bytes_len = gen_range(MIN_LEN, MAX_LEN);
 
     let mut vec = vec![0u8; bytes_len];
@@ -79,7 +72,7 @@ fn gen_bytes() -> Vec<u8> {
 
 
 fn test_client(test_fields: &TestFields) -> HttpBuffer {
-    use multipart::client::Multipart;
+    use client::Multipart;
 
     let request = MockClientRequest::default();
 
@@ -106,7 +99,7 @@ fn test_client(test_fields: &TestFields) -> HttpBuffer {
 }
 
 fn test_server(buf: HttpBuffer, mut fields: TestFields) {
-    use multipart::server::{Multipart, MultipartData};
+    use server::{Multipart, MultipartData};
 
     let mut multipart = Multipart::from_request(buf.for_server())
         .unwrap_or_else(|_| panic!("Buffer should be multipart!"));
@@ -141,12 +134,6 @@ fn test_server(buf: HttpBuffer, mut fields: TestFields) {
 pub struct MockClientRequest {
     boundary: Option<String>,
     content_len: Option<u64>,
-}
-
-impl MockClientRequest {
-    pub fn new() -> MockClientRequest {
-        Self::default()
-    }
 }
 
 impl ClientRequest for MockClientRequest {

--- a/src/server/boundary.rs
+++ b/src/server/boundary.rs
@@ -14,6 +14,7 @@ pub struct BoundaryReader<R> {
     boundary: Vec<u8>,
     search_idx: usize,
     boundary_read: bool,
+    at_end: bool,
 }
 
 impl<R> BoundaryReader<R> where R: Read {
@@ -24,49 +25,66 @@ impl<R> BoundaryReader<R> where R: Read {
             boundary: boundary.into(),
             search_idx: 0,
             boundary_read: false,
+            at_end: false,
         }
     }
 
     fn read_to_boundary(&mut self) -> io::Result<&[u8]> {
+        use log::LogLevel;
+
         let buf = try!(self.buffer.fill_buf());
 
-        if !self.boundary_read {
-            let last_search_idx = self.search_idx;
-            let lookahead_iter = buf[self.search_idx..].windows(self.boundary.len()).enumerate();
+        while !(self.boundary_read || self.at_end) && self.search_idx < buf.len() {
+            let lookahead = &buf[self.search_idx..];
 
-            for (search_idx, maybe_boundary) in lookahead_iter {
-                if maybe_boundary[0] == self.boundary[0] {
-                    self.boundary_read = self.boundary == maybe_boundary;
-                    self.search_idx = last_search_idx + search_idx;
+            let safe_len = cmp::min(lookahead.len(), self.boundary.len());
 
-                    if self.boundary_read {
-                        // if boundary is preceded by CRLF, include it
-                        if self.search_idx >= 2 && &buf[self.search_idx-2..self.search_idx] == b"\r\n" {
-                            self.search_idx = self.search_idx - 2;
-                        }
-                        break;
-                    }
-                }
+            if &lookahead[..safe_len] == &self.boundary[..safe_len] {
+                self.boundary_read = safe_len == self.boundary.len();
+                break;
             }
+
+            self.search_idx += 1;
+        }         
+
+        if self.search_idx >= 2 {
+            self.search_idx -= 2;
         }
+
         debug!("Buf len: {} Search idx: {}", buf.len(), self.search_idx);
-        Ok(&buf[..self.search_idx]) 
+        
+        if log_enabled!(LogLevel::Info) {
+            let _ = ::std::str::from_utf8(buf).map(|buf|
+                info!("Buf: {:?}", buf)
+            );
+        }
+
+        Ok(&buf[..self.search_idx])
     }
 
     #[doc(hidden)]
     pub fn consume_boundary(&mut self) -> io::Result<()> {
         while !self.boundary_read {
             let buf_len = try!(self.read_to_boundary()).len();
+
+            if buf_len == 0 {
+                break;
+            }
+
             self.consume(buf_len);
         }
 
-        let consume_amt = {
-            let boundary_len = self.boundary.len();
-            let buf = try!(self.read_to_boundary());
-            buf.len() + boundary_len
-        };
+        let consume_amt = self.search_idx + self.boundary.len();
 
         self.buffer.consume(consume_amt);
+
+        let mut after_buf = [0u8; 2];
+        // Substitute for Result::expect() being unstable.
+        self.buffer.read(&mut after_buf).unwrap_or_else(|err|
+            panic!("Failed to read 2 bytes after boundary. Reason: {:?}", err)
+        );
+        self.at_end = &after_buf == b"--";
+
         self.search_idx = 0;
         self.boundary_read = false;
  
@@ -128,46 +146,113 @@ fn copy_bytes(src: &[u8], dst: &mut [u8]) {
     }
 }
 
-#[test]
-fn test_boundary() {    
-    const BOUNDARY: &'static str = "--boundary\r\n";
-    const TEST_VAL: &'static str = "\r
---boundary\r
+#[cfg(test)]
+mod test {
+    use super::BoundaryReader;
+
+    use std::cmp;
+
+    use std::io;
+    use std::io::prelude::*;
+
+    const BOUNDARY: &'static str = "--boundary";
+    const TEST_VAL: &'static str = "--boundary\r
 dashed-value-1\r
 --boundary\r
 dashed-value-2\r
---boundary\r
-";
+--boundary--"; 
+        
+    #[test]
+    fn test_boundary() {
+        let _ = ::env_logger::init();        
+        debug!("Testing boundary (no split)");
 
-    ::env_logger::init().unwrap();
+        let src = &mut TEST_VAL.as_bytes();
+        let reader = BoundaryReader::from_reader(src, BOUNDARY);
+        
+        test_boundary_reader(reader);        
+    }
 
-    let src = &mut TEST_VAL.as_bytes();
-    let mut reader = BoundaryReader::from_reader(src, BOUNDARY);
+    struct SplitReader<'a> {
+        left: &'a [u8],
+        right: &'a [u8],
+    }
 
-    let ref mut buf = String::new();
+    impl<'a> SplitReader<'a> {
+        fn split(data: &'a [u8], at: usize) -> SplitReader<'a> {
+            let (left, right) = data.split_at(at);
 
-    debug!("Read 1");
-    let _ = reader.read_to_string(buf).unwrap();
-    debug!("Buf: {:?}", buf);
-    assert!(buf.trim().is_empty());
+            SplitReader { 
+                left: left,
+                right: right,
+            }
+        }
+    }
 
-    buf.clear();
+    impl<'a> Read for SplitReader<'a> {
+        fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+            fn copy_bytes_partial(src: &mut &[u8], dst: &mut [u8]) -> usize {
+                let copy_amt = cmp::min(src.len(), dst.len());
+                super::copy_bytes(&src[..copy_amt], dst);
+                *src = &src[copy_amt..];
+                copy_amt
+            }
 
-    debug!("Consume 1");
-    reader.consume_boundary().unwrap();
+            let mut copy_amt = copy_bytes_partial(&mut self.left, dst);
 
-    debug!("Read 2");
-    let _ = reader.read_to_string(buf).unwrap();
-    assert_eq!(buf.trim(), "dashed-value-1");
-    buf.clear();
+            if copy_amt == 0 {
+                copy_amt = copy_bytes_partial(&mut self.right, dst)
+            };
 
-    debug!("Consume 2");
-    reader.consume_boundary().unwrap();
+            Ok(copy_amt)
+        }
+    }
 
-    debug!("Read 3");
-    let _ = reader.read_to_string(buf).unwrap();
-    assert_eq!(buf.trim(), "dashed-value-2");
+    #[test]
+    fn test_split_boundary() {
+        let _ = ::env_logger::init();        
+        debug!("Testing boundary (split)");
+        
+        // Substitute for `.step_by()` being unstable.
+        for split_at in (0 .. TEST_VAL.len()).filter(|x| x % 2 != 0) {
+            debug!("Testing split at: {}", split_at);
 
-    debug!("Consume 3");
-    reader.consume_boundary().unwrap();
+            let src = SplitReader::split(TEST_VAL.as_bytes(), split_at);
+            let reader = BoundaryReader::from_reader(src, BOUNDARY);
+            test_boundary_reader(reader);
+        }
+
+    }
+
+    fn test_boundary_reader<R: Read>(mut reader: BoundaryReader<R>) {
+        let ref mut buf = String::new();    
+
+        debug!("Read 1");
+        let _ = reader.read_to_string(buf).unwrap();
+        assert!(buf.is_empty(), "Buffer not empty: {:?}", buf);
+        buf.clear();
+
+        debug!("Consume 1");
+        reader.consume_boundary().unwrap();
+
+        debug!("Read 2");
+        let _ = reader.read_to_string(buf).unwrap();
+        assert_eq!(buf, "dashed-value-1");
+        buf.clear();
+
+        debug!("Consume 2");
+        reader.consume_boundary().unwrap();
+
+        debug!("Read 3");
+        let _ = reader.read_to_string(buf).unwrap();
+        assert_eq!(buf, "dashed-value-2");
+        buf.clear();
+
+        debug!("Consume 3");
+        reader.consume_boundary().unwrap();
+
+        debug!("Read 4");
+        let _ = reader.read_to_string(buf).unwrap();
+        assert!(buf.is_empty(), "Buffer not empty: {:?}", buf);        
+    }
 }

--- a/src/server/boundary.rs
+++ b/src/server/boundary.rs
@@ -68,6 +68,10 @@ impl<R> BoundaryReader<R> where R: Read {
 
     #[doc(hidden)]
     pub fn consume_boundary(&mut self) -> io::Result<()> {
+        if self.at_end {
+            return Ok(());
+        }
+
         while !self.boundary_read {
             let buf_len = try!(self.read_to_boundary()).len();
 
@@ -297,6 +301,9 @@ dashed-value-2\r
 
         debug!("Read 4");
         let _ = reader.read_to_string(buf).unwrap();
-        assert!(buf.is_empty(), "Buffer not empty: {:?}", buf);        
+        assert!(buf.is_empty(), "Buffer not empty: {:?}", buf);
+
+        debug!("Extra Consume");
+        reader.consume_boundary().unwrap();
     }
 }

--- a/src/server/buf_read.rs
+++ b/src/server/buf_read.rs
@@ -81,9 +81,16 @@ impl<R: Read> BufRead for CustomBufReader<R> {
 
 impl<R> fmt::Debug for CustomBufReader<R> where R: fmt::Debug {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("BufReader")
+        fmt.write_fmt(format_args!(
+            "CustomBufReader {{ reader: {:?}, buffer: {}/{}}}", 
+            &self.inner, self.cap - self.pos, self.buf.len()
+        ))
+
+        /* FIXME (07/26/15): Switch to this impl after the next Stable release.
+        fmt.debug_struct("CustomBufReader")
             .field("reader", &self.inner)
-            .field("buffer", &format_args!("{}/{}", self.cap - self.pos, self.buf.len()))
+            .field("buffer", &format_args!("{}/{}", ))
             .finish()
+        */
     }
 }

--- a/src/server/buf_read.rs
+++ b/src/server/buf_read.rs
@@ -1,0 +1,89 @@
+use std::cmp;
+use std::fmt;
+
+use std::io::prelude::*;
+use std::io;
+
+const DEFAULT_BUF_SIZE: usize = 64 * 1024;
+
+/// A copy of `std::io::BufReader` with additional methods needed for multipart support.
+pub struct CustomBufReader<R> {
+    inner: R,
+    buf: Vec<u8>,
+    pos: usize,
+    cap: usize,
+}
+
+impl<R: Read> CustomBufReader<R> { 
+    #[doc(hidden)]
+    pub fn new(inner: R) -> Self {
+        CustomBufReader::with_capacity(DEFAULT_BUF_SIZE, inner)
+    }
+
+    #[doc(hidden)]
+    pub fn with_capacity(cap: usize, inner: R) -> Self {
+        CustomBufReader {
+            inner: inner,
+            buf: vec![0; cap],
+            pos: 0,
+            cap: 0,
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn fill_buf_min(&mut self, min: usize) -> io::Result<&[u8]> {
+        if self.pos == self.cap {
+            self.cap = try!(self.inner.read(&mut self.buf));
+            self.pos = 0;
+        } else if min > self.cap - self.pos {
+            self.cap += try!(self.inner.read(&mut self.buf[self.cap..]));
+        }            
+
+        Ok(&self.buf[self.pos..self.cap])
+    }
+
+    #[doc(hidden)]
+    pub fn get_ref(&self) -> &R { &self.inner }
+}
+
+impl<R: Read> Read for CustomBufReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // If we don't have any buffered data and we're doing a massive read
+        // (larger than our internal buffer), bypass our internal buffer
+        // entirely.
+        if self.pos == self.cap && buf.len() >= self.buf.len() {
+            return self.inner.read(buf);
+        }
+        let nread = {
+            let mut rem = try!(self.fill_buf());
+            try!(rem.read(buf))
+        };
+        self.consume(nread);
+        Ok(nread)
+    }
+}
+
+impl<R: Read> BufRead for CustomBufReader<R> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        // If we've reached the end of our internal buffer then we need to fetch
+        // some more data from the underlying reader.
+        if self.pos == self.cap {
+            self.cap = try!(self.inner.read(&mut self.buf));
+            self.pos = 0;
+        }
+        Ok(&self.buf[self.pos..self.cap])
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.pos = cmp::min(self.pos + amt, self.cap);
+    }
+}
+
+impl<R> fmt::Debug for CustomBufReader<R> where R: fmt::Debug {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("BufReader")
+            .field("reader", &self.inner)
+            .field("buffer", &format_args!("{}/{}", self.cap - self.pos, self.buf.len()))
+            .finish()
+    }
+}


### PR DESCRIPTION
@nicolas-cherel 

No externally breaking changes that I can see right now.

I added a new test to make sure that it doesn't break on partial reads. Fixing the partial reads issue required copying `BufReader` from `std` and adding a method that reads more data into the non-empty buffer. I'll be drafting an RFC to have this method added to `BufReader` soon.

The test for Stable fails... because of APIs that have been stabilized since the last Stable release. So... while this is *technically* still compatible with Stable, it doesn't build on it right now. I don't know when the next release is because I don't keep track of the trains. RFC on what to do about this.

Closes #18.