### PR TITLE
Adjustments to client and server APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "multipart"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Austin Bonander <austin.bonander@gmail.com>"]
 
 description = "An extension to the Hyper HTTP library that provides support for POST multipart/form-data requests on for both client and server."

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -72,7 +72,7 @@ impl<S: HttpStream> Multipart<S> {
     ///
     /// ##Errors
     /// If something went wrong with the HTTP stream.
-    pub fn write_text<N: AsRef<str>, V: AsRef<str>>(mut self, name: N, val: V) -> Self {
+    pub fn write_text<N: AsRef<str>, V: AsRef<str>>(&mut self, name: N, val: V) -> &mut Self {
         if self.last_err.is_none() {
             self.last_err = chain_result! {
                 self.write_field_headers(name.as_ref(), None, None),
@@ -94,7 +94,7 @@ impl<S: HttpStream> Multipart<S> {
     /// ##Errors
     /// If there was a problem opening the file (was a directory or didn't exist),
     /// or if something went wrong with the HTTP stream.
-    pub fn write_file<N: AsRef<str>, P: AsRef<Path>>(mut self, name: N, path: P) -> Self {
+    pub fn write_file<N: AsRef<str>, P: AsRef<Path>>(&mut self, name: N, path: P) -> &mut Self {
         if self.last_err.is_none() {     
             let path = path.as_ref();
 
@@ -132,8 +132,8 @@ impl<S: HttpStream> Multipart<S> {
     /// If the reader returned an error, or if something went wrong with the HTTP stream.
     // RFC: How to format this declaration?
     pub fn write_stream<N: AsRef<str>, St: Read>(
-        mut self, name: N, read: &mut St, filename: Option<&str>, content_type: Option<Mime>
-    ) -> Self {
+        &mut self, name: N, read: &mut St, filename: Option<&str>, content_type: Option<Mime>
+    ) -> &mut Self {
         if self.last_err.is_none() {
             let content_type = content_type.unwrap_or_else(::mime_guess::octet_stream);
 

--- a/src/local_test.rs
+++ b/src/local_test.rs
@@ -83,15 +83,15 @@ fn test_client(test_fields: &TestFields) -> HttpBuffer {
     // Intersperse file fields amongst text fields
     for (name, text) in &test_fields.texts {
         if let Some((file_name, file)) = test_files.next() {
-            multipart = multipart.write_stream(file_name, &mut &**file, None, None);
+            multipart.write_stream(file_name, &mut &**file, None, None);
         }
 
-        multipart = multipart.write_text(name, text);    
+        multipart.write_text(name, text);    
     }
 
     // Write remaining files
     for (file_name, file) in test_files {
-       multipart = multipart.write_stream(file_name, &mut &**file, None, None);
+       multipart.write_stream(file_name, &mut &**file, None, None);
     }
 
 
@@ -209,7 +209,6 @@ impl<'a> Read for ServerBuffer<'a> {
 }
 
 impl<'a> ServerRequest for ServerBuffer<'a> {
-    fn is_multipart(&self) -> bool { true }
-    fn boundary(&self) -> Option<&str> { Some(&self.boundary) }
+    fn multipart_boundary(&self) -> Option<&str> { Some(&self.boundary) }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -50,13 +50,11 @@ impl<R> Multipart<R> where R: HttpRequest {
     /// If the given `R: HttpRequest` is a POST request of `Content-Type: multipart/form-data`,
     /// return the wrapped request as `Ok(Multipart<R>)`, otherwise `Err(R)`.
     pub fn from_request(req: R) -> Result<Multipart<R>, R> {
-        if !req.is_multipart() { return Err(req); }
-
-        if req.boundary().is_none() {
+        if req.multipart_boundary().is_none() {
             return Err(req);     
         }
 
-        let boundary = format!("--{}", req.boundary().unwrap());
+        let boundary = format!("--{}", req.multipart_boundary().unwrap());
 
         debug!("Boundary: {}", boundary);
 
@@ -245,10 +243,12 @@ fn get_remainder_after<'a>(needle: &str, haystack: &'a str) -> Option<(&'a str)>
 
 /// A server-side HTTP request that may or may not be multipart.
 pub trait HttpRequest: Read {
-    /// Return `true` if this request is a `multipart/form-data` request, `false` otherwise.
-    fn is_multipart(&self) -> bool;
-    /// Get the boundary string of this request if it is `multipart/form-data`.
-    fn boundary(&self) -> Option<&str>;
+    /// Get the boundary string of this request if it is a POST request
+    /// with the `Content-Type` header set to `multipart/form-data`.
+    ///
+    /// The boundary string should be supplied as an extra value of the `Content-Type` header, e.g.
+    /// `Content-Type: multipart/form-data; boundary=myboundary`.
+    fn multipart_boundary(&self) -> Option<&str>;
 }
 
 /// A field in a multipart request. May be either text or a binary stream (file).


### PR DESCRIPTION
This is a minor breaking change, thus necessitating a version bump.

On the client-side, `Multipart::write_*()` methods now take and return `&mut self` instead of `self`, While this breaks method-chaining with `.send()`, which still requires by-value `self`, it is a general improvement on ergonomics, especially in loops.

On the server-side, `HttpRequest::is_multipart()` was removed, as it was superfluous. `HttpRequest::boundary()` got renamed to `multipart_boundary()` and gained a clarification on its semantics.