### PR TITLE
Fix boundary ending

### DIFF
--- a/src/server/boundary.rs
+++ b/src/server/boundary.rs
@@ -109,7 +109,7 @@ impl<R> BoundaryReader<R> where R: Read {
             }
 
             if &after[..2] != b"\r\n" {
-                self.at_end = after == b"--";
+                self.at_end = &after[..2] == b"--";
 
                 if !self.at_end {
                     return Err(io::Error::new(


### PR DESCRIPTION
Just to mention it, I don’t know if something should be done for the
‘\r\n’ after the boundary ending. Since content after boundary is
supposed to be ignored, I don’t think it needs to be enforced, and does
not need any care about being consumed or not.