### PR TITLE
big file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+This My Fork For my own experiment , if you want to you it feel free but it may bug a lot
+========
+
+
 Multipart + Hyper [![Build Status](https://travis-ci.org/cybergeek94/multipart.svg?branch=master)](https://travis-ci.org/cybergeek94/multipart) [![On Crates.io](https://img.shields.io/crates/v/multipart.svg)](https://crates.io/crates/multipart)
 =========
 

--- a/src/server/buf_read.rs
+++ b/src/server/buf_read.rs
@@ -36,6 +36,9 @@ impl<R: Read> CustomBufReader<R> {
             self.cap = try!(self.inner.read(&mut self.buf));
             self.pos = 0;
         } else if min > self.cap - self.pos {
+            for i in 0..min{
+                self.buf.push(0);
+            }
             self.cap += try!(self.inner.read(&mut self.buf[self.cap..]));
         }            
 


### PR DESCRIPTION
I tried to use this crate to handle file upload in my rustfull applcation. it works perfectly fine but when i tried to upload big file > 64k it fails.
self.inner.read in the buffer returns an error.
This is because self.buff is too small (self.inner.read does not increase the vector size).
to solve this problem i add a loop which push as many u8 which make the vector in the buffer increase.
I tested it and it seems to solve my issue.
Maybe there is a nicer way to do it, i m still learning rust