### PR TITLE
fixed two clippy warnings

### DIFF
--- a/src/client/lazy.rs
+++ b/src/client/lazy.rs
@@ -251,7 +251,7 @@ pub struct PreparedFields<'d> {
 
 impl<'d> PreparedFields<'d> {
     fn from_fields<'n>(fields: &mut Vec<Field<'n, 'd>>, boundary: String, buffer_threshold: Option<u64>) -> Result<Self, LazyIoError<'n>> {
-        let buffer_threshold = buffer_threshold.unwrap_or(u64::max_value());
+        let buffer_threshold = buffer_threshold.unwrap_or(::std::u64::MAX);
 
         let mut prep_fields = Vec::with_capacity(fields.len());
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -202,13 +202,13 @@ impl<B: Read> Multipart<B> {
         let _ = try!(self.source.read(&mut out));
 
         if *b"\r\n" == out {
-            return Ok(true);
+            Ok(true)
         } else {
             if *b"--" != out {
                 warn!("Unexpected 2-bytes after boundary: {:?}", out);
             }
 
-            return Ok(false);
+            Ok(false)
         }
     }
 }


### PR DESCRIPTION
The code is already squeaky clean, so clippy found only two very minor style nits. :+1: